### PR TITLE
Fix json value for currency name

### DIFF
--- a/src/services/btczRates.js
+++ b/src/services/btczRates.js
@@ -13,7 +13,7 @@ const btczRates = {
 
       bitpayData.forEach((value) => {
         const exchangeRate = btczBtcExchangeRate * value.rate;
-        rates.push({ code: value.code, value: value.name, rate: exchangeRate });
+        rates.push({ code: value.code, name: value.name, rate: exchangeRate });
       });
 
       return rates;


### PR DESCRIPTION
The MyBitcoinZ app expects that the currency name is in a attribute
called 'name' and not 'value'. This commit fixes the error.